### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/contracts/vaults/BunnyPool.sol
+++ b/contracts/vaults/BunnyPool.sol
@@ -296,7 +296,7 @@ contract BunnyPool is IStrategyLegacy, RewardsDistributionRecipient, ReentrancyG
     function setRewardsDuration(uint256 _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "period");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/vaults/VaultBunnyBNB.sol
+++ b/contracts/vaults/VaultBunnyBNB.sol
@@ -274,7 +274,7 @@ contract VaultBunnyBNB is VaultController, IStrategy, RewardsDistributionRecipie
     function setRewardsDuration(uint _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "VaultBunnyBNB: reward duration can only be updated after the period ends");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     /* ========== PRIVATE FUNCTIONS ========== */

--- a/contracts/vaults/VaultFlipToCake.sol
+++ b/contracts/vaults/VaultFlipToCake.sol
@@ -261,7 +261,7 @@ contract VaultFlipToCake is VaultController, IStrategy, RewardsDistributionRecip
     function setRewardsDuration(uint _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "VaultFlipToCake: reward duration can only be updated after the period ends");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     /* ========== PRIVATE FUNCTIONS ========== */

--- a/contracts/vaults/VaultQBTBNB.sol
+++ b/contracts/vaults/VaultQBTBNB.sol
@@ -210,7 +210,7 @@ contract VaultQBTBNB is IPresaleLocker, RewardsDistributionRecipientUpgradeable,
     function setRewardsDuration(uint256 _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "VaultQBTBNB: period");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setPresaleEndTime(uint _endTime) external override onlyPresale {

--- a/contracts/vaults/qubit/QubitPool.sol
+++ b/contracts/vaults/qubit/QubitPool.sol
@@ -210,7 +210,7 @@ contract QubitPool is BEP20Upgradeable, IQubitPool, RewardsDistributionRecipient
         require(periodFinish == 0 || block.timestamp > periodFinish, "QubitPool: Not time to set duration");
         rewardsDuration = _rewardsDuration;
 
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function notifyRewardAmount(uint reward) external override(IQubitPool, RewardsDistributionRecipientUpgradeable) onlyRewardsDistribution {

--- a/contracts/vaults/qubit/VaultFlipToQBT.sol
+++ b/contracts/vaults/qubit/VaultFlipToQBT.sol
@@ -234,7 +234,7 @@ contract VaultFlipToQBT is VaultController, IRewardDistributed, RewardsDistribut
     function setRewardsDuration(uint _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "VaultFlipToQBT: reward duration can only be updated after the period ends");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     /* ========== PRIVATE FUNCTIONS ========== */

--- a/contracts/vaults/relay/VaultRelayInternal.sol
+++ b/contracts/vaults/relay/VaultRelayInternal.sol
@@ -275,7 +275,7 @@ contract VaultRelayInternal is VaultController, IStrategy, RewardsDistributionRe
     function setRewardsDuration(uint _rewardsDuration) external onlyOwner {
         require(periodFinish == 0 || block.timestamp > periodFinish, "VaultRelayInternal: reward duration can only be updated after the period ends");
         rewardsDuration = _rewardsDuration;
-        emit RewardsDurationUpdated(rewardsDuration);
+        emit RewardsDurationUpdated(_rewardsDuration);
     }
 
     function setRelayer(address newRelayer) external onlyOwner {


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.